### PR TITLE
Ensure DMCMM lot calculation skips zero-bet trades

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5221,6 +5221,10 @@ double sqDistributedMonteCarloMM(string symbol, int orderType, double price, dou
    }
    string sym = correctSymbol(symbol);
    double lot = dmcmm_calc_lot(sym, MagicNumberA);
+   if(lot <= 0){
+      dmcmm_log("bet is zero, skipping order");
+      return(0);
+   }
    lot = fixLotSize(sym, lot);
    if(MaximumLots > 0 && lot > MaximumLots) lot = MaximumLots;
    return lot;


### PR DESCRIPTION
## Summary
- Avoid order placement when Distributed Monte Carlo bet is zero by logging and returning zero lot

## Testing
- `mql4-compiler MoveCatcher2.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6337a5c0883279601f3969a1198fe