### PR TITLE
Fix possible data loss warning in OrderSelect

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5223,7 +5223,7 @@ void dmcmm_process_history(string symbol,int magic){
       ArraySort(tickets,WHOLE_ARRAY,0,MODE_ASCEND);
       for(int j=0;j<ArraySize(tickets);j++){
          ulong ticket=tickets[j];
-         if(OrderSelect(ticket,SELECT_BY_TICKET)){
+         if(OrderSelect((int)ticket,SELECT_BY_TICKET)){
             double pl=OrderProfit()+OrderSwap()+OrderCommission();
             bool win=(pl >= DMCMM_WinEpsMoney);
             if(win) dmcmm_on_win(); else dmcmm_on_lose();


### PR DESCRIPTION
## Summary
- cast ticket ID to int before calling OrderSelect to prevent data loss warning

## Testing
- `mql4compiler MoveCatcher2.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b669f90a6c8327abad2a9e8f4eb6c7