### PR TITLE
Fix undefined LongToStr calls

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5007,7 +5007,7 @@ string dmcmm_seq_to_string(){
    string s="";
    int size = ArraySize(dmcmm_seq);
    for(int i=0;i<size;i++){
-      s += LongToStr(dmcmm_seq[i]);
+      s += LongToString(dmcmm_seq[i]);
       if(i<size-1) s += ",";
    }
    return s;
@@ -5041,7 +5041,7 @@ void dmcmm_save(string symbol,int magic){
       string fname = StringFormat("DMCMM_%s_%d.csv", symbol, magic);
       int handle = FileOpen(fname, FILE_WRITE|FILE_CSV);
       if(handle!=INVALID_HANDLE){
-         FileWrite(handle, dmcmm_seq_to_string(), LongToStr(dmcmm_stock), IntegerToString(dmcmm_streak), LongToStr((long)dmcmm_lastTicket));
+         FileWrite(handle, dmcmm_seq_to_string(), LongToString(dmcmm_stock), IntegerToString(dmcmm_streak), LongToString((long)dmcmm_lastTicket));
          FileClose(handle);
       }
    }


### PR DESCRIPTION
## Summary
- Replace obsolete LongToStr calls with LongToString
- Ensure integer values are converted to strings correctly when saving DMCMM state

## Testing
- `mql4 -h` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6754f40dc832790c35d40c0d6ad60