### PR TITLE
Fix missing LongToString helper in DMCMM utilities

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5003,6 +5003,10 @@ void dmcmm_array_insert(long &arr[], int index, long value){
    arr[index] = value;
 }
 
+string LongToString(long value){
+   return StringFormat("%I64d", value);
+}
+
 string dmcmm_seq_to_string(){
    string s="";
    int size = ArraySize(dmcmm_seq);


### PR DESCRIPTION
## Summary
- add LongToString function using StringFormat

## Testing
- `mql4compiler MoveCatcher2.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bedf90688327bd95cbc4bc0d2b96