### PR TITLE
バックテスト開始時にDMCMM状態を初期化

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -436,7 +436,11 @@ int OnInit() {
    objMaxTradesPerDay = new CMaxTradesPerDay();
    objMinMaxSLPT = new CMinMaxSLPT();
 
-   dmcmm_load(Symbol(), MagicNumberA);
+   if(IsTesting()){
+      dmcmm_reset();
+   } else {
+      dmcmm_load(Symbol(), MagicNumberA);
+   }
 
 
    // OnInit  rules
@@ -5033,6 +5037,7 @@ void dmcmm_log(int level, string text){
 }
 
 void dmcmm_save(string symbol,int magic){
+   if(IsTesting()) return;
    if(DMCMM_PersistMode == DMCMM_PERSIST_GV){
       string base = StringFormat("DMCMM_%s_%d_", symbol, magic);
       int len = ArraySize(dmcmm_seq);
@@ -5055,6 +5060,7 @@ void dmcmm_save(string symbol,int magic){
 }
 
 void dmcmm_load(string symbol,int magic){
+   if(IsTesting()) return;
    if(DMCMM_PersistMode == DMCMM_PERSIST_GV){
       string base = StringFormat("DMCMM_%s_%d_", symbol, magic);
       if(!GlobalVariableCheck(base+"LEN")){


### PR DESCRIPTION
## 概要
- バックテスト時は前回の状態を読み込まず、DMCMMを初期化
- テストモードでは永続化処理(dmcmm_save/load)をスキップ

## テスト
- `metaeditor64.exe /compile:MoveCatcher2.mq4` (MetaTraderコンパイラが見つからず実行不可)


------
https://chatgpt.com/codex/tasks/task_e_68b70ab114c88327999fd946a32a4647