### PR TITLE
fix: 最新履歴反映後にロット計算

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5302,6 +5302,8 @@ double sqDistributedMonteCarloMM(string symbol, int orderType, double price, dou
       return (mmLotsIfNoMM);
    }
    string sym = correctSymbol(symbol);
+   // 最新の勝敗結果を反映してからロットを算出する
+   dmcmm_process_history(sym, MagicNumberA);
    double lot = dmcmm_calc_lot(sym, MagicNumberA);
    if(lot <= 0){
       dmcmm_log(1, "bet is zero, skipping order");


### PR DESCRIPTION
## Summary
- ロット計算前にDMCMMの勝敗履歴を処理し、最新状態に基づくロジックへ修正

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68b7118acda88327bd7f25c451b50ad9