### PR TITLE
Clarify streak-based stock handling

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5188,14 +5188,12 @@ void dmcmm_on_win(){
 }
 
 void dmcmm_on_lose(){
-   if(dmcmm_streak <=5){
-      dmcmm_streak=0;
-   } else {
-      long consecutiveProfit=(dmcmm_streak-3)*5-8;
-      long normalProfit=dmcmm_streak-2;
+   if(dmcmm_streak >=6){
+      long consecutiveProfit = (dmcmm_streak-3)*5-8;
+      long normalProfit = dmcmm_streak-2;
       dmcmm_stock += (consecutiveProfit - normalProfit);
-      dmcmm_streak=0;
    }
+   dmcmm_streak = 0;
    int len = ArraySize(dmcmm_seq);
    if(len>0){
       long add = dmcmm_seq[0] + dmcmm_seq[len-1];


### PR DESCRIPTION
## Summary
- ensure stock reward is applied only when win streak is 6 or more
- reset streak after processing to align with specification

## Testing
- `wine metaeditor64.exe /compile:MoveCatcher2.mq4 /log` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b752cf960083279fdbf96b3e3ac02a