### PR TITLE
ストック消費条件の見直し

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5193,7 +5193,7 @@ void dmcmm_on_lose(){
    dmcmm_average();
    len = ArraySize(dmcmm_seq);
    string branch="";
-   if(len>0 && dmcmm_seq[0] <= dmcmm_stock){
+   if(len>0 && dmcmm_seq[0] > 0 && dmcmm_seq[0] <= dmcmm_stock){
       dmcmm_stock -= dmcmm_seq[0];
       dmcmm_seq[0]=0;
       branch="STOCK";


### PR DESCRIPTION
## 概要
- 先頭要素が0の場合にストック消費を行わないよう修正

## テスト
- `python3 - <<'PY'
# 簡易チェック: 先頭要素0かつストック0の場合にストック消費が発生しないことを確認
seq=[0,1,1]
stock=0
if len(seq)>0 and seq[0]>0 and seq[0]<=stock:
    stock-=seq[0]
    seq[0]=0
print(seq, stock)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b80f1686a0832788ce80b21888708d