### PR TITLE
WIN時の3要素数列処理の修正

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5165,8 +5165,8 @@ void dmcmm_on_win(){
    } else if(len==3){
       // 初期数列から1番目と2番目を削除し、残った値を分解
       dmcmm_array_remove(dmcmm_seq,0);      // 1番目を削除
-      dmcmm_array_remove(dmcmm_seq,1);      // 2番目（元の3番目）を削除
-      long v = dmcmm_seq[0];                // 残った中間値
+      dmcmm_array_remove(dmcmm_seq,0);      // 2番目（元の2番目）を削除
+      long v = dmcmm_seq[0];                // 残った末尾値
       ArrayResize(dmcmm_seq,2);
       if(v%2==0){
          long h=v/2; dmcmm_seq[0]=h; dmcmm_seq[1]=h; branch="LEN3E";


### PR DESCRIPTION
## 概要
- DMCMMのWIN処理で3要素の数列から削除する要素が誤っていたため、残る値がズレていました
- 1番目と2番目を削除するよう修正し、末尾値を正しく分解

## テスト
- `python3` による簡易シミュレーションで数列処理を確認


------
https://chatgpt.com/codex/tasks/task_e_68b81d2a15448327b864ce2179e502db