### PR TITLE
Fix DMCMM zero redistribution total calculation

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5208,9 +5208,8 @@ void dmcmm_on_lose(){
       int size = ArraySize(dmcmm_seq);
       int n = size - 1;
       // 合計は先頭0化後の合計に再配布値を加えて算出
-      long total = 0;
-      for(int i=0; i<size; i++) total += dmcmm_seq[i];
-      total += redistribute;
+      long total = redistribute;
+      for(int i=1; i<size; i++) total += dmcmm_seq[i];
       if(n>0){
          if(redistribute < n){
             if(size > 1) dmcmm_seq[1] += redistribute;


### PR DESCRIPTION
## Summary
- align DMCMM zero-generation total computation with spec to avoid double counting

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68b867d729dc832798999b6a23708df0