### PR TITLE
fix: correct zero redistribution total

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5209,9 +5209,8 @@ void dmcmm_on_lose(){
       int size = ArraySize(dmcmm_seq);
       int n = size - 1;
       // 合計は先頭0化後の合計に再配布値を加えて算出
-      long total = 0;
-      for(int i=0; i<size; i++) total += dmcmm_seq[i];
-      total += redistribute;
+      long total = redistribute;
+      for(int i=1; i<size; i++) total += dmcmm_seq[i];
       if(n>0){
          if(redistribute < n){
             if(size > 1) dmcmm_seq[1] += redistribute;


### PR DESCRIPTION
## Summary
- ensure zero-generation total sums sequence after head zeroing plus redistribution

## Testing
- `mql5compiler MoveCatcher2.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86b699ba883279dabacfbb76808b9