### PR TITLE
0生成時の合計計算を仕様通りに修正

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5208,9 +5208,10 @@ void dmcmm_on_lose(){
       dmcmm_seq[0] = 0;
       int size = ArraySize(dmcmm_seq);
       int n = size - 1;
-      // 合計は先頭0化後の合計に再配布値を加えて算出
-      long total = redistribute;
-      for(int i=1; i<size; i++) total += dmcmm_seq[i];
+      // 合計は先頭0化後の合計に再配布値を足して算出（ダブルカウント防止）
+      long total = 0;
+      for(int i=0; i<size; i++) total += dmcmm_seq[i];
+      total += redistribute;
       if(n>0){
          if(redistribute < n){
             if(size > 1) dmcmm_seq[1] += redistribute;


### PR DESCRIPTION
## Summary
- 0生成処理での合計算出を先頭要素を0化後に再配布値を加算する方式へ修正

## Testing
- `wine MetaEditor.exe /compile:MoveCatcher2.mq4 /include: /log` *(command not found: wine)*

------
https://chatgpt.com/codex/tasks/task_e_68b86d4ac1088327b34cf805d344c64a