### PR TITLE
Fix DMCMM redistribution total calculation

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5217,9 +5217,10 @@ void dmcmm_on_lose(){
       dmcmm_seq[0] = 0;
       int size = ArraySize(dmcmm_seq);
       int n = size - 1;
-      // 合計は先頭0化後の合計に再配布値を足して算出（ダブルカウント防止）
-      long total = redistribute;
-      for(int i=1; i<size; i++) total += dmcmm_seq[i];
+      // 先頭を0化した後の合計に再配布値を足して合計数列値を算出（仕様準拠）
+      long total = 0;
+      for(int i=0; i<size; i++) total += dmcmm_seq[i];
+      total += redistribute;
       if(n>0){
          if(redistribute < n){
             if(size > 1) dmcmm_seq[1] += redistribute;


### PR DESCRIPTION
## Summary
- correct zero-generation sum in DMCMM to follow specification

## Testing
- `metaeditor /compile:MoveCatcher2.mq4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b87f449d2c8327aabeca7861268854