### PR TITLE
ストック消費条件の厳密化

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5201,7 +5201,8 @@ void dmcmm_on_lose(){
    dmcmm_average();
    len = ArraySize(dmcmm_seq);
    string branch="";
-   if(len>0 && dmcmm_seq[0] <= dmcmm_stock){
+   // ストック消費（左>0 の場合のみ）
+   if(len>0 && dmcmm_seq[0] > 0 && dmcmm_seq[0] <= dmcmm_stock){
       dmcmm_stock -= dmcmm_seq[0];
       dmcmm_seq[0] = 0;
       branch = "STOCK";


### PR DESCRIPTION
## 概要
- DMCMMのストック消費条件を修正し、先頭数列値が0の場合に誤って処理されないようにしました。

## テスト
- `true` を実行（テストスクリプトなし）

------
https://chatgpt.com/codex/tasks/task_e_68b8c65c3b108327adbcdeed4c2621d7