### PR TITLE
fix: 数列0生成時の合計計算を仕様通りに修正

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5214,7 +5214,7 @@ void dmcmm_on_lose(){
       int n = size - 1;
       // 合計数列値 = （先頭0化後の合計）＋再配布値（仕様準拠）
       long sumZero = 0;
-      for(int i = 0; i < size; i++) sumZero += dmcmm_seq[i];
+      for(int i = 1; i < size; i++) sumZero += dmcmm_seq[i];
       long total = sumZero + redistribute;
       if(n <= 0){
          branch += " R0";


### PR DESCRIPTION
## Summary
- 先頭要素0化後の合計算出で先頭要素を除外し、再配布値を正しく加算

## Testing
- `mql4compiler MoveCatcher2.mq4` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b8ce20ac24832799a71d630604a7ed