### PR TITLE
DMCMMの整数平均計算を仕様通りに修正

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5137,7 +5137,7 @@ void dmcmm_average(){
          return;
       }
       long rem = total % (long)n;
-      long avg = total / (long)n;
+      long avg = (total - rem) / (long)n;  // 整数平均（端数切捨て）
       dmcmm_array_remove(dmcmm_seq,0);
       for(int i = 0; i < n; i++) dmcmm_seq[i] = avg;
       if(rem > 0) dmcmm_seq[0] += rem;
@@ -5146,7 +5146,7 @@ void dmcmm_average(){
    } else {
       int n = len;
       long rem = total % (long)n;
-      long avg = total / (long)n;
+      long avg = (total - rem) / (long)n;  // 整数平均（端数切捨て）
       for(int i = 0; i < n; i++) dmcmm_seq[i] = avg;
       if(rem > 0 && n > 1) dmcmm_seq[1] += rem;
       branch = (rem > 0 && n > 1) ? "L1B1" : "L1B0";


### PR DESCRIPTION
## 概要
- DMCMMの数列平均化処理で端数を切り捨てる整数平均計算に修正

## テスト
- `make test`（テストターゲットが存在しないため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68b8cf993f2c8327924543df077f0bfe