### PR TITLE
Fix DMCMM sequence edge handling for short arrays

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5196,7 +5196,7 @@ void dmcmm_on_lose(){
    int len = ArraySize(dmcmm_seq);
    // 数列個数に関わらず末尾に（左+右）を追加する（仕様準拠）
    long left = (len>0) ? dmcmm_seq[0] : 0;
-   long right = (len>0) ? dmcmm_seq[len-1] : 0;
+   long right = (len>1) ? dmcmm_seq[len-1] : 0; // len==1 の場合は右端を0とみなす
    long add = left + right;
    dmcmm_array_insert(dmcmm_seq, len, add);
    dmcmm_average();


### PR DESCRIPTION
## Summary
- avoid double-counting when processing loss with single-element sequences by treating missing right side as zero

## Testing
- `mql4 2>&1 | head -n 20` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d98935ac83279d9ac485a96c056f