### PR TITLE
Refine stock consumption logic in DMCMM

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5203,7 +5203,8 @@ void dmcmm_on_lose(){
    len = ArraySize(dmcmm_seq);
    string branch="";
    // ストック消費（初期数列(1)がストック以下なら）
-   if(len>0 && dmcmm_seq[0] <= dmcmm_stock){
+   // ストック消費は左端が1以上かつストック以下のときのみ実行する
+   if(len>0 && dmcmm_seq[0] > 0 && dmcmm_seq[0] <= dmcmm_stock){
       dmcmm_stock -= dmcmm_seq[0];
       dmcmm_seq[0] = 0;
       branch = "STOCK";


### PR DESCRIPTION
## Summary
- ensure stock is consumed only when the first sequence value is positive

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68b8dbf9aa048327be2036edbe95fa8b