### PR TITLE
DMCMM のストック消費ロジックを仕様通りに修正

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5202,12 +5202,13 @@ void dmcmm_on_lose(){
    dmcmm_average();
    len = ArraySize(dmcmm_seq);
    string branch="";
-   // ストック消費（初期数列(1)がストック以下なら）
-   // ストック消費は左端が1以上かつストック以下のときのみ実行する
-   if(len>0 && dmcmm_seq[0] > 0 && dmcmm_seq[0] <= dmcmm_stock){
+   // ストック消費（初期数列(1)がストック以下なら、0も含む）
+   if(len>0 && dmcmm_seq[0] <= dmcmm_stock){
+      if(dmcmm_seq[0] > 0){
+         branch = "STOCK"; // 0消費のみの場合はログを残さない
+      }
       dmcmm_stock -= dmcmm_seq[0];
       dmcmm_seq[0] = 0;
-      branch = "STOCK";
    }
    if(len>0 && dmcmm_seq[0] >= 1){
       long redistribute = dmcmm_seq[0];


### PR DESCRIPTION
## Summary
- 単数列分解管理モンテカルロ法のストック消費条件を仕様に合わせて0も対象に変更
- ストックを消費しない場合の不要なログ出力を抑制

## Testing
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68b8ee48a8148327b962dbc7367bc3ed