### PR TITLE
Ensure DMCMM streak resets on non-{0,1} wins

### DIFF
--- a/MoveCatcher2.mq4
+++ b/MoveCatcher2.mq4
@@ -5158,10 +5158,17 @@ void dmcmm_average(){
 
 void dmcmm_on_win(){
    int len = ArraySize(dmcmm_seq);
-   if(len<2) return;
+   if(len < 2){
+      dmcmm_reset();
+      return;
+   }
    long left = dmcmm_seq[0];
    long right = dmcmm_seq[len-1];
-   if(len==2 && left==0 && right==1) dmcmm_streak++;
+   if(len==2 && left==0 && right==1){
+      dmcmm_streak++;
+   } else {
+      dmcmm_streak = 0;
+   }
    string branch="";
    if(len==2){
       dmcmm_seq[0]=0; dmcmm_seq[1]=1;


### PR DESCRIPTION
## Summary
- reset DMCMM state when sequence length is invalid during win processing
- clear winning streak whenever win occurs on non-{0,1} sequence

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68b8f016092c8327818207e05cf5f2cb